### PR TITLE
Switch back from spec to source file, instead of creating a spec for the spec.

### DIFF
--- a/lib/spec-maker.coffee
+++ b/lib/spec-maker.coffee
@@ -25,15 +25,10 @@ warnOfUnreplacement = ->
   ].join(" ")
 
 replaceSrcLocWithSpecLoc = (path) ->
-  srcLocation = config('srcLocation')
-  specLocation = config('specLocation')
-
-  if new RegExp(specLocation).test(path)
-    fromPath = specLocation
-    toPath = srcLocation
-  else
-    fromPath = srcLocation
-    toPath = specLocation
+  fromPath   = config('srcLocation')
+  toPath     = config('specLocation')
+  isPathSpec = new RegExp(toPath).test(path)
+  [fromPath, toPath] = [toPath, fromPath] if isPathSpec
 
   origPath = path
   newPath = path.replace(

--- a/spec/spec-maker-spec.coffee
+++ b/spec/spec-maker-spec.coffee
@@ -79,6 +79,7 @@ describe "SpecMaker", ->
         )
 
     describe 'returning from a spec to the source file', ->
+
       beforeEach ->
         openFileAndSetEditors('spec/some-path/sample-spec.js')
 


### PR DESCRIPTION
Currently, once you switch to/create a spec for a source file, running `spec-maker:open-or-create-spec` again creates a new spec for the spec.

This pull request modifies the `spec-maker:open-or-create-spec` command to detect that the current file is a spec file, and returns to or opens the source file the spec file tests.
