### PR TITLE
Remove path and suffix defaults

### DIFF
--- a/lib/spec-maker.coffee
+++ b/lib/spec-maker.coffee
@@ -76,17 +76,17 @@ module.exports =
     # ie `my-app-file.js` -> `my-app-file-spec.js`
     specSuffix:
       type: 'string'
-      default: '-spec'
+      default: ''
     # Where the specs live
     # ie `lib/views/my-app-view.js` -> `spec/views/my-app-view-spec.js`
     specLocation:
       type: 'string'
-      default: 'spec/'
+      default: ''
     # Where the source code lives
     # ie `lib/my-app-file.js` or `src/my-app-file.js`
     srcLocation:
       type: 'string'
-      default: 'lib/'
+      default: ''
     # Which pane a spec is opened into.
     # ie `left`, `right`, or `none`
     # Currently Atom only seems to support left/right but not above/below,

--- a/spec/spec-maker-spec.coffee
+++ b/spec/spec-maker-spec.coffee
@@ -36,6 +36,9 @@ describe "SpecMaker", ->
     waitsForPromise ->
       openFile()
     runs ->
+      atom.config.set('spec-maker.specSuffix', '-spec')
+      atom.config.set('spec-maker.specLocation', '/spec')
+      atom.config.set('spec-maker.srcLocation', '/lib')
       jasmine.attachToDOM(workspaceView())
       spyOn(atom.workspace, 'open').andCallThrough()
 


### PR DESCRIPTION
Defaulting these to a directory or suffix prevents being able to have an empty directory or suffix which is a completely valid use case.
